### PR TITLE
Documentation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import Strava
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 		// ...
         // Setup `StravaClient`
-        StravaClient.instance.configure(clientId: "<#Your Client Id#>", clientSecret: "<#Your Client Secret#>", callbackURL:"yourConfiguredCallbackURL")
+        StravaClient.instance.configure(clientId: <#Your Client Id#> (as a UInt64), clientSecret: "<#Your Client Secret#>", callbackURL:"yourConfiguredCallbackURL")
         //...
         return true
     }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import Strava
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 		// ...
         // Setup `StravaClient`
-        StravaClient.instance.configure(clientId: "<#Your Client Id#>", clientSecret: "<#Your Client Secret#>"")
+        StravaClient.instance.configure(clientId: "<#Your Client Id#>", clientSecret: "<#Your Client Secret#>", callbackURL:"yourConfiguredCallbackURL")
         //...
         return true
     }

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import Strava
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 		// ...
         // Setup `StravaClient`
-        StravaClient.instance.setup(clientId: "<#Your Client Id#>", clientSecret: "<#Your Client Secret#>"")
+        StravaClient.instance.configure(clientId: "<#Your Client Id#>", clientSecret: "<#Your Client Secret#>"")
         //...
         return true
     }


### PR DESCRIPTION
Documentation refers to .setup method in using the library, this method does not exist, it seems to be .configure instead.